### PR TITLE
Initial work

### DIFF
--- a/autoscaling_group.tf
+++ b/autoscaling_group.tf
@@ -1,0 +1,149 @@
+# TODO: All hard-coded things need to be uplifted
+# Deal with the fact we're only supporting lambda scaling from v4.5.0
+locals {
+  userdata = <<-EOF
+Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+MIME-Version: 1.0
+--==BOUNDARY==
+Content-Type: text/cloud-boothook; charset="us-ascii"
+DOCKER_USERNS_REMAP=${var.enable_docker_user_namespace_remap} \
+DOCKER_EXPERIMENTAL=${var.enable_docker_experimental} \
+  /usr/local/bin/bk-configure-docker.sh
+--==BOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash -xv
+BUILDKITE_STACK_NAME="${local.name}" \
+BUILDKITE_STACK_VERSION=${local.ci_stack_data.buildkite_stack_version} \
+BUILDKITE_SCALE_IN_IDLE_PERIOD=${var.scale_in_idle_period} \
+BUILDKITE_SECRETS_BUCKET="${var.secrets_bucket}" \
+BUILDKITE_AGENT_TOKEN="${var.buildkite_agent_token}" \
+BUILDKITE_AGENT_TOKEN_PATH="" \
+BUILDKITE_AGENTS_PER_INSTANCE="${var.agents_per_instance}" \
+BUILDKITE_AGENT_TAGS="${var.buildkite_agent_tags}" \
+BUILDKITE_AGENT_TIMESTAMP_LINES="${var.buildkite_agent_timestamp_lines}" \
+BUILDKITE_AGENT_EXPERIMENTS="${var.buildkite_agent_experiments}" \
+BUILDKITE_AGENT_RELEASE="${var.buildkite_agent_release}" \
+BUILDKITE_QUEUE="${var.buildkite_queue}" \
+BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT=${var.enable_git_mirrors_experiment} \
+BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${var.bootstrap_script_url}" \
+BUILDKITE_AUTHORIZED_USERS_URL="${var.authorized_users_url}" \
+BUILDKITE_ECR_POLICY=${var.ecr_access_policy} \
+BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=false \
+BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS=${var.buildkite_additional_sudo_permissions} \
+AWS_DEFAULT_REGION=${local.aws_region} \
+SECRETS_PLUGIN_ENABLED=${var.enable_secrets_plugin} \
+ECR_PLUGIN_ENABLED=${var.enable_ecr_plugin} \
+DOCKER_LOGIN_PLUGIN_ENABLED=${var.enable_docker_login_plugin} \
+AWS_REGION=${local.aws_region} \
+  /usr/local/bin/bk-install-elastic-stack.sh
+--==BOUNDARY==--
+EOF
+}
+
+resource aws_iam_instance_profile main {
+  name_prefix = format("%s-Role-", local.name)
+  role        = aws_iam_role.main.name
+}
+
+resource aws_security_group main {
+  count       = local.build_security_group
+  name_prefix = format("%s-", local.name)
+  vpc_id      = local.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource aws_security_group_rule ssh_ingress {
+  count             = local.build_ssh_ingress
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.main[0].id
+}
+
+resource aws_launch_template main {
+  name_prefix            = format("%s-", local.name)
+  image_id               = local.image_id
+  instance_type          = ""
+  ebs_optimized          = true
+  update_default_version = true
+  iam_instance_profile {
+    name = aws_iam_instance_profile.main.name
+  }
+  key_name = var.key_name
+
+  # TODO: Consider not doing this at all and simply going with the default
+  # subnet settings for public ip address. The variable could be used when this
+  # module creates the subnets only, otherwise, just take the subnet's default?
+  network_interfaces {
+    associate_public_ip_address = var.associate_public_ip_address
+    security_groups = [
+      (
+        var.security_group_id != "" ? var.security_group_id : aws_security_group.main[0].id
+      ),
+    ]
+  }
+
+  block_device_mappings {
+    device_name = var.root_volume_name
+
+    ebs {
+      volume_size           = var.root_volume_size
+      volume_type           = var.root_volume_type
+      delete_on_termination = true
+    }
+  }
+
+  user_data = base64encode(local.userdata)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource aws_autoscaling_group main {
+  name_prefix         = format("%s-", local.name)
+  min_size            = var.min_size
+  desired_capacity    = 0
+  max_size            = var.max_size
+  vpc_zone_identifier = var.subnets
+
+  lifecycle {
+    ignore_changes = [
+      desired_capacity,
+    ]
+  }
+
+  mixed_instances_policy {
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.main.id
+        version            = "$Latest"
+      }
+
+      dynamic "override" {
+        for_each = var.instance_types
+        content {
+          instance_type = override.value
+        }
+      }
+    }
+
+    # Ondemand and spot configuration dependent mostly on var.spot_enabled
+    # Follow - https://github.com/HENNGE/terraform-aws-autoscaling-mixed-instances/blob/master/main.tf
+    instances_distribution {
+      on_demand_base_capacity                  = var.on_demand_base_capacity
+      on_demand_percentage_above_base_capacity = var.on_demand_percentage_above_base_capacity
+      spot_allocation_strategy                 = var.spot_allocation_strategy
+      spot_instance_pools                      = var.spot_allocation_strategy == "lowest-price" ? var.spot_instance_pools : null
+      spot_max_price                           = var.spot_price
+    }
+  }
+}

--- a/buildkite-agent-scaler/main.tf
+++ b/buildkite-agent-scaler/main.tf
@@ -1,0 +1,107 @@
+data aws_region current {}
+
+locals {
+  aws_region        = data.aws_region.current.name
+  default_s3_bucket = local.aws_region == "us-east-1" ? "buildkite-lambdas" : "buildkite-lambdas-${local.aws_region}"
+  s3_bucket         = var.s3_bucket == "" ? local.default_s3_bucket : var.s3_bucket
+  function_name     = var.function_name
+}
+
+resource aws_iam_role this {
+  name_prefix = format("%s-", local.function_name)
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource aws_iam_role_policy lambda_autoscaling {
+  name = "lambda_autoscaling"
+  role = aws_iam_role.this.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "autoscaling:SetDesiredCapacity",
+          "autoscaling:DescribeAutoScalingGroups",
+          "cloudwatch:PutMetricData",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource aws_lambda_function this {
+  function_name = local.function_name
+  s3_bucket     = local.s3_bucket
+  s3_key        = var.s3_key
+  description   = "Parse Cloudflare logs related to workers and send to Datadog"
+  timeout       = "120"
+  role          = aws_iam_role.this.arn
+  handler       = "handler"
+  runtime       = "go1.x"
+  memory_size   = "128"
+
+  environment {
+    variables = {
+      BUILDKITE_AGENT_TOKEN = var.buildkite_agent_token
+      BUILDKITE_QUEUE       = var.buildkite_queue
+      AGENTS_PER_INSTANCE   = format("%s", var.agents_per_instance)
+      CLOUDWATCH_METRICS    = format("%s", var.cloudwatch_metrics)
+      DISABLE_SCALE_IN      = format("%s", var.disable_scale_in)
+      ASG_NAME              = var.asg_name
+      MIN_SIZE              = format("%s", var.min_size)
+      MAX_SIZE              = format("%s", var.max_size)
+      LAMBDA_TIMEOUT        = var.lambda_timeout
+      LAMBDA_INTERVAL       = var.lambda_interval
+      SCALE_OUT_FACTOR      = var.scale_out_factor
+      INCLUDE_WAITING       = format("%s", var.include_waiting)
+    }
+  }
+  depends_on = [aws_cloudwatch_log_group.this]
+}
+
+resource aws_cloudwatch_log_group this {
+  name              = format("/aws/lambda/%s", local.function_name)
+  retention_in_days = 1
+}
+
+resource aws_cloudwatch_event_rule every_minute {
+  name_prefix         = format("%s-", local.function_name)
+  description         = "Fires every minute"
+  schedule_expression = "rate(1 minute)"
+}
+
+resource aws_cloudwatch_event_target run_cloudflare_workers_datadog_every_minute {
+  rule      = aws_cloudwatch_event_rule.every_minute.name
+  target_id = "cloudflare_workers_datadog"
+  arn       = aws_lambda_function.this.arn
+}
+
+resource aws_lambda_permission lambda_autoscaling_cw_exec {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.this.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.every_minute.arn
+}

--- a/buildkite-agent-scaler/variables.tf
+++ b/buildkite-agent-scaler/variables.tf
@@ -1,0 +1,67 @@
+variable function_name {
+  type = string
+}
+
+variable asg_name {
+  type = string
+}
+
+variable buildkite_queue {
+  type = string
+}
+
+variable buildkite_agent_token {
+  type = string
+}
+
+variable min_size {
+  type = number
+}
+
+variable max_size {
+  type = number
+}
+
+variable agents_per_instance {
+  type = number
+}
+
+variable s3_bucket {
+  type    = string
+  default = ""
+}
+
+variable s3_key {
+  type    = string
+  default = "buildkite-agent-scaler/v1.0.0/handler.zip"
+}
+
+variable cloudwatch_metrics {
+  type    = bool
+  default = true
+}
+
+variable disable_scale_in {
+  type    = bool
+  default = true
+}
+
+variable lambda_timeout {
+  type    = string
+  default = "50s"
+}
+
+variable lambda_interval {
+  type    = string
+  default = "10s"
+}
+
+variable scale_out_factor {
+  type    = string
+  default = "1.0"
+}
+
+variable include_waiting {
+  type    = bool
+  default = false
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,55 @@
+resource aws_iam_role main {
+  name = format("%s-Role", local.name)
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": [
+            "autoscaling.amazonaws.com",
+            "ec2.amazonaws.com"
+        ]
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+# TODO: This is awful, take the real bucket or make one and use that here
+resource aws_iam_role_policy s3 {
+  name = "s3_all"
+  role = aws_iam_role.main.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "s3:*"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+# TODO: Do the right thing
+resource aws_iam_role_policy_attachment ecr {
+  role       = aws_iam_role.main.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}
+
+# TODO: Do the right thing
+resource aws_iam_role_policy_attachment asg {
+  role       = aws_iam_role.main.name
+  policy_arn = "arn:aws:iam::aws:policy/AutoScalingFullAccess"
+}

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,0 +1,13 @@
+module autoscaling_lambda {
+  source = "./buildkite-agent-scaler"
+
+  function_name         = format("%s-autoscaling", local.name)
+  asg_name              = aws_autoscaling_group.main.name
+  buildkite_queue       = var.buildkite_queue
+  buildkite_agent_token = var.buildkite_agent_token
+  min_size              = var.min_size
+  max_size              = var.max_size
+  agents_per_instance   = var.agents_per_instance
+  scale_out_factor      = var.scale_out_factor
+  include_waiting       = var.scale_out_for_waiting_jobs
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,27 @@
+
+locals {
+  vpc_id               = var.vpc_id
+  build_security_group = var.security_group_id == "" ? 1 : 0
+
+  # Build ssh ingress if we're both making a security group in this module and
+  # have either a key_name or authorized users url set.
+  build_ssh_ingress = var.security_group_id == "" && (var.key_name != "" || var.authorized_users_url != "") ? 1 : 0
+
+  aws_region = data.aws_region.current.name
+  name       = var.name
+
+  # Data used to track along with the built upstream stacks. I'm not convinced
+  # this is really the right way to do this.
+  ci_stack_data = {
+    buildkite_stack_version = "v5.0.0"
+
+    # This selector is derived from the compiled map in the upstream stack's
+    # AWSRegion2AMI map. This is going to have to be updated to include the
+    # OS type when that lands as a release.
+    ami_selector                   = "buildkite-stack-linux-2020-09-08T23-08-45Z*"
+    autoscaling_lambda_bucket_name = local.aws_region == "us-east-1" ? "buildkite-lambdas" : "buildkite-lambdas-${local.aws_region}"
+    autoscaling_lambda_key         = "buildkite-agent-scaler/v1.0.0/handler.zip"
+  }
+
+  image_id = var.image_id == "" ? data.aws_ami.main.image_id : var.image_id
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,11 @@
+data aws_region current {}
+
+data aws_ami main {
+  most_recent = true
+  owners      = ["172840064832"] # Buildkite
+
+  filter {
+    name   = "name"
+    values = [local.ci_stack_data.ami_selector]
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,8 @@
+output image_id {
+  value = local.image_id
+}
+
+# Helpful for debugging purposes
+output userdata {
+  value = base64encode(local.userdata)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,223 @@
+variable name {
+  type = string
+}
+
+variable buildkite_queue {
+  type        = string
+  default     = "default"
+  description = "Queue name that agents will use, targeted in pipeline steps using 'queue={value}'"
+}
+
+variable buildkite_agent_release {
+  type    = string
+  default = "stable"
+}
+
+variable agents_per_instance {
+  type    = number
+  default = 1
+}
+
+variable max_size {
+  type    = number
+  default = 10
+}
+
+variable min_size {
+  type    = number
+  default = 0
+}
+
+variable image_id {
+  type    = string
+  default = ""
+}
+
+variable instance_types {
+  type = list
+  default = [
+    "t2.nano"
+  ]
+}
+
+variable image_id_parameter {
+  type    = string
+  default = ""
+}
+
+variable key_name {
+  default     = ""
+  description = "Optional - SSH keypair used to access the buildkite instances, setting this will enable SSH ingress"
+}
+
+variable authorized_users_url {
+  type        = string
+  default     = ""
+  description = "Optional - HTTPS or S3 URL to periodically download ssh authorized_keys from, setting this will enable SSH ingress"
+}
+variable bootstrap_script_url {
+  type        = string
+  default     = ""
+  description = "Optional - HTTPS or S3 URL to run on each instance during boot"
+}
+
+variable buildkite_agent_token {
+  type        = string
+  description = "Buildkite agent registration token"
+  default     = ""
+}
+
+variable subnets {
+  type    = list
+  default = []
+}
+
+variable vpc_id {
+  type = string
+}
+
+variable secrets_bucket {
+  type    = string
+  default = ""
+}
+
+variable buildkite_agent_tags {
+  type    = string
+  default = ""
+}
+
+variable security_group_id {
+  type        = string
+  default     = ""
+  description = "Optional - Security group id to assign to instances"
+}
+
+variable associate_public_ip_address {
+  type        = bool
+  default     = true
+  description = "Associate instances with public IP addresses"
+}
+
+variable root_volume_size {
+  type        = number
+  default     = 250
+  description = "Size of each instance's root EBS volume (in GB)"
+}
+
+variable root_volume_name {
+  type        = string
+  default     = "/dev/xvda"
+  description = "Name of the root block device for your AMI"
+}
+
+variable root_volume_type {
+  type        = string
+  default     = "gp2"
+  description = "Type of root volume to use"
+}
+
+variable enable_ecr_plugin {
+  type        = bool
+  default     = true
+  description = "Enables ecr plugin for all pipelines"
+}
+
+variable enable_docker_login_plugin {
+  type        = bool
+  default     = true
+  description = "Enables Docker user namespace remapping so docker runs as buildkite-agent"
+}
+
+variable enable_docker_user_namespace_remap {
+  type        = bool
+  default     = true
+  description = "Enables Docker user namespace remapping so docker runs as buildkite-agent"
+}
+
+variable enable_docker_experimental {
+  type        = bool
+  default     = false
+  description = "Enables Docker experimental features"
+}
+
+variable enable_secrets_plugin {
+  type        = bool
+  default     = true
+  description = "Enables s3-secrets plugin for all pipelines"
+}
+
+variable buildkite_agent_timestamp_lines {
+  type        = bool
+  default     = false
+  description = "Set to true to prepend timestamps to every line of output"
+}
+
+variable buildkite_additional_sudo_permissions {
+  type        = string
+  default     = ""
+  description = "Optional - Comma separated list of commands to allow the buildkite-agent user to run using sudo."
+}
+
+variable scale_in_idle_period {
+  type        = number
+  default     = 1800
+  description = "Number of seconds UnfinishedJobs must equal 0 before scale down"
+}
+
+variable scale_out_factor {
+  type    = string
+  default = "1.0"
+}
+
+variable scale_out_for_waiting_jobs {
+  type    = bool
+  default = false
+}
+
+variable ecr_access_policy {
+  type        = string
+  default     = "none"
+  description = "ECR access policy to give container instances"
+}
+
+variable buildkite_agent_experiments {
+  type        = string
+  default     = ""
+  description = "Agent experiments to enable, comma delimited. See https://github.com/buildkite/agent/blob/master/EXPERIMENTS.md."
+}
+
+variable enable_git_mirrors_experiment {
+  type        = bool
+  default     = false
+  description = "Enables the git-mirrors experiment in the agent"
+}
+
+variable on_demand_base_capacity {
+  description = "Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances"
+  type        = number
+  default     = 0
+}
+
+variable on_demand_percentage_above_base_capacity {
+  description = "Percentage split between on-demand and Spot instances above the base on-demand capacity."
+  type        = number
+  default     = 100
+}
+
+variable spot_allocation_strategy {
+  description = "How to allocate capacity across the Spot pools. Valid values: 'lowest-price', 'capacity-optimized'."
+  type        = string
+  default     = "capacity-optimized"
+}
+
+variable spot_instance_pools {
+  description = "Number of Spot pools per availability zone to allocate capacity. EC2 Auto Scaling selects the cheapest Spot pools and evenly allocates Spot capacity across the number of Spot pools that you specify. Diversifies your Spot capacity across multiple instance types to find the best pricing."
+  type        = number
+  default     = 2
+}
+
+variable spot_price {
+  description = "The price to use for reserving spot instances"
+  type        = string
+  default     = ""
+}

--- a/version.tf
+++ b/version.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.13.0, < 0.14"
+
+  required_providers {
+    aws = ">= 2.49, < 4.0"
+  }
+}


### PR DESCRIPTION
This is the initial proof of concept getting to some kind of parity with - https://github.com/buildkite/elastic-ci-stack-for-aws

Working towards - https://github.com/buildkite/elastic-ci-stack-for-aws/issues/246#issuecomment-694592688

Notes:
- `cf-signal` breaks, but exits are handled so it's possibly ok, but clunky.
- Associate public IP should maybe go with defaults for custom vpc? My opinion is this should be used on the subnets created by this module and otherwise your subnets should do their default.
